### PR TITLE
增加远程小组件代码调试

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+dev/node_modules

--- a/dev/README.md
+++ b/dev/README.md
@@ -1,0 +1,25 @@
+## 组件远程调试服务
+
+使用前，确保手机和node运行的服务在同一个局域网。
+
+1. 在本目录运行node服务
+
+```bash
+npm install
+npm run serve
+```
+正确的话，会在console得到已开启调试的提示。
+
+2. 服务运行起来之后，修改`debug.js`的ip和端口。
+
+```bash
+const nodeServeUrl = `http://**:8023` // 8023为默认端口
+```
+
+3. 确保步骤2完成之后，将`debug.js`的代码粘贴到scriptable上。当然要在桌面小组件上查看啦。
+
+4. 编写你的小组件代码，位于`/www/latest.js`。
+
+5. 改动之后，到scriptable粘贴的`debug.js`脚本代码上点击运行。回到桌面查看修改，由于scripatable的更新机制，或许需要多次运行才行。
+
+6. 组件代码完成之后就可以放到最后的目录上啦。

--- a/dev/app.js
+++ b/dev/app.js
@@ -1,0 +1,12 @@
+require('colors')
+const express = require("express")
+const app = express()
+
+app.use(express.static("www"))
+
+// 端口可自定义
+app.listen(8023, () => {
+  console.log("已开启小组件调试...".green)
+  console.log("编写www/latest.js模板。完成编写后，即可将latest.js粘贴到对应的目录上完成最终编写。".cyan)
+  console.log("**注意粘贴ip和端口到/debug.js".red)
+})

--- a/dev/debug.js
+++ b/dev/debug.js
@@ -1,0 +1,23 @@
+// node服务跑起来之后，将这个脚本粘贴到scriptable以调试组件
+// 能访问到的远程脚本url(调试的url)
+/**
+ * node服务跑起来之后，将这个脚本粘贴到scriptable以调试组件
+ * localJsUrl为能访问到的远程脚本url(调试的url)
+ * 注意填写自己调试服务器的ip和端口（默认8023）
+ * 注意保证调试手机和调试服务在同一个局域网上
+ */
+const nodeServeUrl = `http://{YOU_IP_ADDRESS}:8023`
+const localJsUrl = `${nodeServeUrl}/latest.js?d=${new Date().getTime()}`
+let req = new Request(localJsUrl)
+let data = await req.loadString()
+// 存储脚本的路径
+const filePrePath = `${FileManager.local().documentsDirectory()}`
+
+// 存储
+await FileManager.local().writeString(`${filePrePath}/latest.js`, data)
+
+const Module = importModule(`${filePrePath}/latest.js`)
+
+const m = new Module()
+
+m.init()

--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -1,0 +1,384 @@
+{
+  "name": "debug",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "accepts": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npm.taobao.org/accepts/download/accepts-1.3.7.tgz",
+      "integrity": "sha1-UxvHJlF6OytB+FACHGzBXqq1B80=",
+      "requires": {
+        "mime-types": "~2.1.24",
+        "negotiator": "0.6.2"
+      }
+    },
+    "array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npm.taobao.org/array-flatten/download/array-flatten-1.1.1.tgz?cache=0&sync_timestamp=1574313384951&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Farray-flatten%2Fdownload%2Farray-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
+    "body-parser": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npm.taobao.org/body-parser/download/body-parser-1.19.0.tgz",
+      "integrity": "sha1-lrJwnlfJxOCab9Zqj9l5hE9p8Io=",
+      "requires": {
+        "bytes": "3.1.0",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "on-finished": "~2.3.0",
+        "qs": "6.7.0",
+        "raw-body": "2.4.0",
+        "type-is": "~1.6.17"
+      }
+    },
+    "bytes": {
+      "version": "3.1.0",
+      "resolved": "http://registry.npm.taobao.org/bytes/download/bytes-3.1.0.tgz",
+      "integrity": "sha1-9s95M6Ng4FiPqf3oVlHNx/gF0fY="
+    },
+    "colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npm.taobao.org/colors/download/colors-1.4.0.tgz",
+      "integrity": "sha1-xQSRR51MG9rtLJztMs98fcI2D3g="
+    },
+    "content-disposition": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npm.taobao.org/content-disposition/download/content-disposition-0.5.3.tgz",
+      "integrity": "sha1-4TDK9+cnkIfFYWwgB9BIVpiYT70=",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "http://registry.npm.taobao.org/content-type/download/content-type-1.0.4.tgz",
+      "integrity": "sha1-4TjMdeBAxyexlm/l5fjJruJW/js="
+    },
+    "cookie": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npm.taobao.org/cookie/download/cookie-0.4.0.tgz?cache=0&sync_timestamp=1587525865178&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcookie%2Fdownload%2Fcookie-0.4.0.tgz",
+      "integrity": "sha1-vrQ35wIrO21JAZ0IhmUwPr6cFLo="
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npm.taobao.org/cookie-signature/download/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npm.taobao.org/debug/download/debug-2.6.9.tgz?cache=0&sync_timestamp=1600502894812&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdebug%2Fdownload%2Fdebug-2.6.9.tgz",
+      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "http://registry.npm.taobao.org/depd/download/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "http://registry.npm.taobao.org/destroy/download/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "http://registry.npm.taobao.org/ee-first/download/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npm.taobao.org/encodeurl/download/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "http://registry.npm.taobao.org/escape-html/download/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npm.taobao.org/etag/download/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    },
+    "express": {
+      "version": "4.17.1",
+      "resolved": "https://registry.npm.taobao.org/express/download/express-4.17.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fexpress%2Fdownload%2Fexpress-4.17.1.tgz",
+      "integrity": "sha1-RJH8OGBc9R+GKdOcK10Cb5ikwTQ=",
+      "requires": {
+        "accepts": "~1.3.7",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.19.0",
+        "content-disposition": "0.5.3",
+        "content-type": "~1.0.4",
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.1.2",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.5",
+        "qs": "6.7.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.1.2",
+        "send": "0.17.1",
+        "serve-static": "1.14.1",
+        "setprototypeof": "1.1.1",
+        "statuses": "~1.5.0",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      }
+    },
+    "finalhandler": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npm.taobao.org/finalhandler/download/finalhandler-1.1.2.tgz",
+      "integrity": "sha1-t+fQAP/RGTjQ/bBTUG9uur6fWH0=",
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
+        "unpipe": "~1.0.0"
+      }
+    },
+    "forwarded": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npm.taobao.org/forwarded/download/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npm.taobao.org/fresh/download/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+    },
+    "http-errors": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npm.taobao.org/http-errors/download/http-errors-1.7.2.tgz?cache=0&sync_timestamp=1593407676624&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fhttp-errors%2Fdownload%2Fhttp-errors-1.7.2.tgz",
+      "integrity": "sha1-T1ApzxMjnzEDblsuVSkrz7zIXI8=",
+      "requires": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npm.taobao.org/iconv-lite/download/iconv-lite-0.4.24.tgz?cache=0&sync_timestamp=1594184264130&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ficonv-lite%2Fdownload%2Ficonv-lite-0.4.24.tgz",
+      "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npm.taobao.org/inherits/download/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "ip": {
+      "version": "1.1.5",
+      "resolved": "http://registry.npm.taobao.org/ip/download/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+    },
+    "ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npm.taobao.org/ipaddr.js/download/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha1-v/OFQ+64mEglB5/zoqjmy9RngbM="
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npm.taobao.org/media-typer/download/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npm.taobao.org/merge-descriptors/download/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npm.taobao.org/methods/download/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+    },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npm.taobao.org/mime/download/mime-1.6.0.tgz?cache=0&sync_timestamp=1590596706367&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fmime%2Fdownload%2Fmime-1.6.0.tgz",
+      "integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE="
+    },
+    "mime-db": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npm.taobao.org/mime-db/download/mime-db-1.44.0.tgz?cache=0&sync_timestamp=1600831210195&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fmime-db%2Fdownload%2Fmime-db-1.44.0.tgz",
+      "integrity": "sha1-+hHF6wrKEzS0Izy01S8QxaYnL5I="
+    },
+    "mime-types": {
+      "version": "2.1.27",
+      "resolved": "https://registry.npm.taobao.org/mime-types/download/mime-types-2.1.27.tgz",
+      "integrity": "sha1-R5SfmOJ56lMRn1ci4PNOUpvsAJ8=",
+      "requires": {
+        "mime-db": "1.44.0"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "negotiator": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npm.taobao.org/negotiator/download/negotiator-0.6.2.tgz",
+      "integrity": "sha1-/qz3zPUlp3rpY0Q2pkiD/+yjRvs="
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npm.taobao.org/on-finished/download/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
+    "parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npm.taobao.org/parseurl/download/parseurl-1.3.3.tgz",
+      "integrity": "sha1-naGee+6NEt/wUT7Vt2lXeTvC6NQ="
+    },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npm.taobao.org/path-to-regexp/download/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "proxy-addr": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npm.taobao.org/proxy-addr/download/proxy-addr-2.0.6.tgz",
+      "integrity": "sha1-/cIzZQVEfT8vLGOO0nLK9hS7sr8=",
+      "requires": {
+        "forwarded": "~0.1.2",
+        "ipaddr.js": "1.9.1"
+      }
+    },
+    "qs": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npm.taobao.org/qs/download/qs-6.7.0.tgz",
+      "integrity": "sha1-QdwaAV49WB8WIXdr4xr7KHapsbw="
+    },
+    "range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npm.taobao.org/range-parser/download/range-parser-1.2.1.tgz",
+      "integrity": "sha1-PPNwI9GZ4cJNGlW4SADC8+ZGgDE="
+    },
+    "raw-body": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npm.taobao.org/raw-body/download/raw-body-2.4.0.tgz",
+      "integrity": "sha1-oc5vucm8NWylLoklarWQWeE9AzI=",
+      "requires": {
+        "bytes": "3.1.0",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npm.taobao.org/safe-buffer/download/safe-buffer-5.1.2.tgz",
+      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "http://registry.npm.taobao.org/safer-buffer/download/safer-buffer-2.1.2.tgz",
+      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo="
+    },
+    "send": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npm.taobao.org/send/download/send-0.17.1.tgz",
+      "integrity": "sha1-wdiwWfeQD3Rm3Uk4vcROEd2zdsg=",
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.7.2",
+        "mime": "1.6.0",
+        "ms": "2.1.1",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.1",
+        "statuses": "~1.5.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.1.1.tgz",
+          "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo="
+        }
+      }
+    },
+    "serve-static": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npm.taobao.org/serve-static/download/serve-static-1.14.1.tgz",
+      "integrity": "sha1-Zm5jbcTwEPfvKZcKiKZ0MgiYsvk=",
+      "requires": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.17.1"
+      }
+    },
+    "setprototypeof": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npm.taobao.org/setprototypeof/download/setprototypeof-1.1.1.tgz",
+      "integrity": "sha1-fpWsskqpL1iF4KvvW6ExMw1K5oM="
+    },
+    "statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npm.taobao.org/statuses/download/statuses-1.5.0.tgz?cache=0&sync_timestamp=1587327902535&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fstatuses%2Fdownload%2Fstatuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+    },
+    "toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npm.taobao.org/toidentifier/download/toidentifier-1.0.0.tgz",
+      "integrity": "sha1-fhvjRw8ed5SLxD2Uo8j013UrpVM="
+    },
+    "type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npm.taobao.org/type-is/download/type-is-1.6.18.tgz",
+      "integrity": "sha1-TlUs0F3wlGfcvE73Od6J8s83wTE=",
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      }
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/unpipe/download/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npm.taobao.org/utils-merge/download/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npm.taobao.org/vary/download/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+    }
+  }
+}

--- a/dev/package.json
+++ b/dev/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "debug",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "serve": "node app.js"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "colors": "^1.4.0",
+    "express": "^4.17.1"
+  }
+}

--- a/dev/www/latest.js
+++ b/dev/www/latest.js
@@ -11,7 +11,6 @@ class Im3xWidget {
   constructor(arg, loader) {
     this.arg = arg
     this.loader = loader
-    this.github = 'https://github.com/im3x/Scriptables'
     this.fileName = module.filename.split('Documents/')[1]
     this.widgetSize = config.widgetFamily
   }
@@ -33,39 +32,36 @@ class Im3xWidget {
    */
   async renderSmall() {
     let w = new ListWidget()
-    let t = w.addText("❤️\n你好\n点击查阅文档")
-    t.centerAlignText()
-    t.font = Font.lightSystemFont(14)
-    w.url = this.loader ? this.getURIScheme('open-url', {
-      url: this.github
-    }) : this.github
+    w.addText("已开启调试！")
     return w
   }
   /**
    * 渲染中尺寸组件
    */
   async renderMedium() {
-    return await this.renderSmall()
+    let w = new ListWidget()
+    w.addText("已开启调试！")
+    return w
   }
   /**
    * 渲染大尺寸组件
    */
   async renderLarge() {
-    return await this.renderSmall()
+    let w = new ListWidget()
+    w.addText("已开启调试！")
+    return w
   }
 
   /**
-   * 用户传递的组件自定义点击操作
-   */
+ * 用户传递的组件自定义点击操作
+ */
   async runActions() {
     let { act, data } = this.parseQuery()
     if (!act) return
-    if (act === 'open-url') {
-      Safari.openInApp(data['url'], false)
-    }
   }
 
   // 获取跳转自身 urlscheme
+  // w.url = this.getURIScheme("copy", "data-to-copy")
   getURIScheme(act, data) {
     let _raw = typeof data === 'object' ? JSON.stringify(data) : data
     let _data = Data.fromString(_raw)
@@ -73,6 +69,7 @@ class Im3xWidget {
     return `${URLScheme.forRunningScript()}?&act=${act}&data=${_b64}`
   }
   // 解析 urlscheme 参数
+  // { act: "copy", data: "copy" }
   parseQuery() {
     const { act, data } = args['queryParameters']
     if (!act) return { act }
@@ -176,19 +173,15 @@ class Im3xWidget {
    */
   async test() {
     if (config.runsInWidget) return
-    try {
-      this.widgetSize = 'small'
-      let w1 = await this.render()
-      await w1.presentSmall()
-      this.widgetSize = 'medium'
-      let w2 = await this.render()
-      await w2.presentMedium()
-      this.widgetSize = 'large'
-      let w3 = await this.render()
-      await w3.presentLarge()
-    } catch (e) {
-      console.warn(e)
-    }
+    this.widgetSize = 'small'
+    let w1 = await this.render()
+    await w1.presentSmall()
+    this.widgetSize = 'medium'
+    let w2 = await this.render()
+    await w2.presentMedium()
+    this.widgetSize = 'large'
+    let w3 = await this.render()
+    await w3.presentLarge()
   }
 
   /**
@@ -208,4 +201,4 @@ module.exports = Im3xWidget
 // await new Im3xWidget('').test()
 
 // 如果是组件单独使用（桌面配置选择这个组件使用，则取消注释这一行：
-// await new Im3xWidget(args.widgetParameter).init()
+// await new Im3xWidget(args.widgetParameter, true).init()

--- a/lol/latest.js
+++ b/lol/latest.js
@@ -1,0 +1,141 @@
+//
+// 通用框架插件模版代码
+// 项目地址：https://github.com/im3x/Scriptables
+//
+
+class Im3xWidget {
+  /**
+   * 初始化
+   * @param arg 外部传递过来的参数
+   */
+  constructor(arg) {
+    this.arg = arg
+    this.widgetSize = config.widgetFamily
+  }
+  /**
+   * 渲染组件
+   */
+  async render() {
+    if (this.widgetSize === 'medium') {
+      return await this.renderMedium()
+    } else if (this.widgetSize === 'large') {
+      return await this.renderLarge()
+    } else {
+      return await this.renderSmall()
+    }
+  }
+
+  /**
+   * 渲染小尺寸组件
+   */
+  async renderSmall() {
+    let w = new ListWidget()
+    w.addText("不支持尺寸")
+    return w
+  }
+  /**
+   * 渲染中尺寸组件
+   */
+  async renderMedium() {
+    let w = new ListWidget()
+    w.addText("不支持尺寸")
+    return w
+  }
+  /**
+   * 渲染大尺寸组件
+   */
+  async renderLarge() {
+    let w = new ListWidget()
+    w.addText("不支持尺寸")
+    return w
+  }
+
+  /**
+   * 渲染标题
+   * @param widget 组件对象
+   * @param icon 图标url地址
+   * @param title 标题
+   */
+  async renderHeader(widget, icon, title) {
+    let header = widget.addStack()
+    header.centerAlignContent()
+    let _icon = header.addImage(await this.getImage(icon))
+    _icon.imageSize = new Size(14, 14)
+    _icon.cornerRadius = 4
+    header.addSpacer(10)
+    let _title = header.addText(title)
+    _title.textColor = Color.white()
+    _title.textOpacity = 0.7
+    _title.font = Font.boldSystemFont(12)
+    widget.addSpacer(15)
+    return widget
+  }
+
+  /**
+   * 获取api数据
+   * @param api api地址
+   */
+  async getData(api) {
+    let req = new Request(api)
+    return await req.loadJSON()
+  }
+  /**
+   * 加载远程图片
+   * @param url string 图片地址
+   * @return image
+   */
+  async getImage(url) {
+    let req = new Request(url)
+    return await req.loadImage()
+  }
+
+  /**
+   * 给图片加上半透明遮罩
+   * @param img 要处理的图片对象
+   * @return image
+   */
+  async shadowImage(img) {
+    let ctx = new DrawContext()
+    ctx.size = img.size
+    ctx.drawImageInRect(img, new Rect(0, 0, img.size['width'], img.size['height']))
+    // 图片遮罩颜色、透明度设置
+    ctx.setFillColor(new Color("#000000", 0.7))
+    ctx.fillRect(new Rect(0, 0, img.size['width'], img.size['height']))
+    let res = await ctx.getImage()
+    return res
+  }
+
+  /**
+   * 编辑测试使用
+   */
+  async test() {
+    if (config.runsInWidget) return
+    this.widgetSize = 'small'
+    let w1 = await this.render()
+    await w1.presentSmall()
+    this.widgetSize = 'medium'
+    let w2 = await this.render()
+    await w2.presentMedium()
+    this.widgetSize = 'large'
+    let w3 = await this.render()
+    await w3.presentLarge()
+  }
+
+  /**
+   * 组件单独在桌面运行时调用
+   */
+  async init() {
+    if (!config.runsInWidget) return
+    let widget = await this.render()
+    Script.setWidget(widget)
+    Script.complete()
+  }
+}
+
+module.exports = Im3xWidget
+
+// 如果是在编辑器内编辑、运行、测试，则取消注释这行，便于调试：
+// await new Im3xWidget().test()
+
+// 如果是组件单独使用（桌面配置选择这个组件使用，则取消注释这一行：
+// await new Im3xWidget(args.widgetParameter).init()

--- a/lol/latest.js
+++ b/lol/latest.js
@@ -11,7 +11,7 @@ class Im3xWidget {
   constructor(arg, loader) {
     this.arg = arg
     this.loader = loader
-    this.github = 'https://github.com/GzhiYi/Scriptables'
+    this.github = 'https://github.com/im3x/Scriptables'
     this.fileName = module.filename.split('Documents/')[1]
     this.widgetSize = config.widgetFamily
   }


### PR DESCRIPTION
本地起node服务后，通过获取远程脚本的方式，在scriptable上读取局域网node服务上的小组件脚本以便于调试。